### PR TITLE
Correct condition of loading ovs module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+shfmt:
+	go get github.com/contiv-experimental/sh/cmd/shfmt
+	find . -type f -name "*.sh" -exec shfmt -w -i 4 -p {} \;

--- a/build_image.sh
+++ b/build_image.sh
@@ -6,7 +6,7 @@ REPOSITORY="contiv/ovs"
 IMAGE=$REPOSITORY:${NETPLUGIN_CONTAINER_TAG:-latest}
 
 function get_image_id() {
-	docker inspect --format '{{.ID}}' $IMAGE || :
+    docker inspect --format '{{.ID}}' $IMAGE || :
 }
 
 old_image=$(get_image_id)
@@ -16,6 +16,6 @@ docker build -t $IMAGE -t $REPOSITORY:latest .
 new_image=$(get_image_id)
 
 if [ -n "$old_image" ] && [ "$old_image" != "$new_image" ]; then
-	echo Removing old image $old_image
-	docker rmi -f $old_image >/dev/null 2>&1 || true
+    echo Removing old image $old_image
+    docker rmi -f $old_image >/dev/null 2>&1 || true
 fi

--- a/ovsInit.sh
+++ b/ovsInit.sh
@@ -4,51 +4,51 @@
 set -euo pipefail
 
 if ! lsmod | cut -d" " -f1 | grep -q openvswitch; then
-    echo "INFO: Load kernel module: openvswitch"
-	modprobe openvswitch
-	sleep 2
+    echo "INFO: Loading kernel module: openvswitch"
+    modprobe openvswitch
+    sleep 2
 fi
 
 mkdir -p /var/run/openvswitch /var/log/contiv
 
 if [ -d "/etc/openvswitch" ]; then
-	if [ -f "/etc/openvswitch/conf.db" ]; then
-		echo "INFO: The Open vSwitch database exists"
-	else
-		echo "INFO: The Open VSwitch database doesn't exist"
-		echo "INFO: Creating the Open VSwitch database..."
-		ovsdb-tool create /etc/openvswitch/conf.db /usr/share/openvswitch/vswitch.ovsschema
-	fi
+    if [ -f "/etc/openvswitch/conf.db" ]; then
+        echo "INFO: The Open vSwitch database exists"
+    else
+        echo "INFO: The Open VSwitch database doesn't exist"
+        echo "INFO: Creating the Open VSwitch database..."
+        ovsdb-tool create /etc/openvswitch/conf.db /usr/share/openvswitch/vswitch.ovsschema
+    fi
 else
-	echo "CRITICAL: Open vSwitch is not mounted from host"
-	exit 1
+    echo "CRITICAL: Open vSwitch is not mounted from host"
+    exit 1
 fi
 
 echo "INFO: Starting ovsdb-server..."
 ovsdb-server --remote=punix:/var/run/openvswitch/db.sock \
-	--remote=db:Open_vSwitch,Open_vSwitch,manager_options \
-	--private-key=db:Open_vSwitch,SSL,private_key \
-	--certificate=db:Open_vSwitch,SSL,certificate \
-	--bootstrap-ca-cert=db:Open_vSwitch,SSL,ca_cert \
-	--log-file=/var/log/contiv/ovs-db.log -vsyslog:info -vfile:info \
-	--pidfile /etc/openvswitch/conf.db &
+    --remote=db:Open_vSwitch,Open_vSwitch,manager_options \
+    --private-key=db:Open_vSwitch,SSL,private_key \
+    --certificate=db:Open_vSwitch,SSL,certificate \
+    --bootstrap-ca-cert=db:Open_vSwitch,SSL,ca_cert \
+    --log-file=/var/log/contiv/ovs-db.log -vsyslog:info -vfile:info \
+    --pidfile /etc/openvswitch/conf.db &
 OVSDB_PID=$!
 
 echo "INFO: Starting ovs-vswitchd"
 ovs-vswitchd -v --pidfile --detach --log-file=/var/log/contiv/ovs-vswitchd.log \
-	-vconsole:err -vsyslog:info -vfile:info &
+    -vconsole:err -vsyslog:info -vfile:info &
 VSWITCHD_PID=$!
 
 retry=0
 while ! ovsdb-client list-dbs | grep -q Open_vSwitch; do
-	if [[ ${retry} -eq 5 ]]; then
-		echo "CRITICAL: Failed to start ovsdb in 5 seconds."
-		exit 1
-	else
-		echo "INFO: Waiting for ovsdb to start..."
-		sleep 1
-		((retry += 1))
-	fi
+    if [[ ${retry} -eq 5 ]]; then
+        echo "CRITICAL: Failed to start ovsdb in 5 seconds."
+        exit 1
+    else
+        echo "INFO: Waiting for ovsdb to start..."
+        sleep 1
+        ((retry += 1))
+    fi
 done
 
 echo "INFO: Setting OVS manager (tcp)..."
@@ -60,8 +60,8 @@ ovs-vsctl set-manager ptcp:6640
 STATUS=0
 
 for pid in $OVSDB_PID $VSWITCHD_PID; do
-	echo "INFO: waiting for pid $pid"
-	wait $pid || let STATUS=1
+    echo "INFO: waiting for pid $pid"
+    wait $pid || let STATUS=1
 done
 
 exit $STATUS

--- a/ovsInit.sh
+++ b/ovsInit.sh
@@ -3,7 +3,8 @@
 
 set -euo pipefail
 
-if [[ $(lsmod | cut -d" " -f1 | grep -q openvswitch) -eq 1 ]]; then
+if ! lsmod | cut -d" " -f1 | grep -q openvswitch; then
+    echo "INFO: Load kernel module: openvswitch"
 	modprobe openvswitch
 	sleep 2
 fi
@@ -39,7 +40,7 @@ ovs-vswitchd -v --pidfile --detach --log-file=/var/log/contiv/ovs-vswitchd.log \
 VSWITCHD_PID=$!
 
 retry=0
-while [[ $(ovsdb-client list-dbs | grep -c Open_vSwitch) -eq 0 ]]; do
+while ! ovsdb-client list-dbs | grep -q Open_vSwitch; do
 	if [[ ${retry} -eq 5 ]]; then
 		echo "CRITICAL: Failed to start ovsdb in 5 seconds."
 		exit 1


### PR DESCRIPTION
`grep -q` hints the result in return code instead of stdout, as a
result the kernel module would not be loaded as expected.

Signed-off-by: Wei Tie <wtie@cisco.com>