### PR TITLE
Ability to pass extra flags via env vars to ovs-vswitchd and ovsdb-server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,6 @@ RUN mkdir -p /etc/openvswitch \
  && echo 'http://dl-cdn.alpinelinux.org/alpine/v3.4/main' >> /etc/apk/repositories \
  && apk --no-cache add \
       openvswitch=2.5.0-r0 ca-certificates bash
-
+ENV OVSVSWITCHD_EXTRA_FLAGS "-v"
+ENV OVSDBSERVER_EXTRA_FLAGS ""
 COPY runtime-scripts/ /scripts/

--- a/runtime-scripts/start-ovs-vswitchd.sh
+++ b/runtime-scripts/start-ovs-vswitchd.sh
@@ -37,7 +37,7 @@ while ! ovsdb-client list-dbs | grep -q Open_vSwitch; do
 done
 
 echo "INFO: Starting ovs-vswitchd"
-ovs-vswitchd -v --pidfile &
+ovs-vswitchd "${OVSVSWITCHD_EXTRA_FLAGS}" --pidfile &
 VSWITCHD_PID=$!
 
 sleep 2

--- a/runtime-scripts/start-ovsdb-server.sh
+++ b/runtime-scripts/start-ovsdb-server.sh
@@ -38,4 +38,4 @@ exec ovsdb-server --remote=punix:/var/run/openvswitch/db.sock \
 	--remote=db:Open_vSwitch,Open_vSwitch,manager_options \
 	--private-key=db:Open_vSwitch,SSL,private_key \
 	--certificate=db:Open_vSwitch,SSL,certificate \
-	--bootstrap-ca-cert=db:Open_vSwitch,SSL,ca_cert
+	--bootstrap-ca-cert=db:Open_vSwitch,SSL,ca_cert "${OVSDBSERVER_EXTRA_FLAGS}"


### PR DESCRIPTION
My use-case is to set log levels which a bit high (especially for ovs-vswitchd).
This could be done with OVSVSWITCHD_EXTRA_FLAGS (set to "-v" by default) and OVSDBSERVER_EXTRA_FLAGS 